### PR TITLE
Fix counter to not be global variable

### DIFF
--- a/codewars/6kyu/Multiples-of-three-and-five/answer.js
+++ b/codewars/6kyu/Multiples-of-three-and-five/answer.js
@@ -4,7 +4,7 @@ function solution(number){
   //check if each number is a multiple of 3 or 5
   //add number to sum if it is
   let sum = 0
-  for (i = 0; i < number; i++) {
+  for (let i = 0; i < number; i++) {
     if (i % 3 === 0 || i % 5 === 0) {
       sum += i
     }


### PR DESCRIPTION
👋 since PRs are welcome, I wanted to point out that (in case it wasn’t already known) omitting a var or let on a variable declaration means it gets declared as a global variable when running in [sloppy mode](https://developer.mozilla.org/en-US/docs/Glossary/Sloppy_mode). In [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) this would be be caught as an error; in case you or someone reading this isn't familiar, strict mode can be enabled by placing a `'use strict';` comment either at the top of the function body you want strict, or top of the file for everything. Alternatively, if you're using real ES Modules (or a compiler which follows the ES Module spec accurately) [modules automatically run under strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode#Strict_mode_for_modules) without the string pragma necessary. Keep in mind some transpilers do not automatically use strict mode and instead make you opt-in. You can check to see whether the transpiled output has the `”use strict";` pragma.