### PR TITLE
Improve efficiency of the solution to the "Find Odd Item" problem

### DIFF
--- a/codewars/6kyu/Find-the-odd-int/answer.js
+++ b/codewars/6kyu/Find-the-odd-int/answer.js
@@ -1,23 +1,43 @@
-//First attempt
-//Feel free to make a PR with code comments on how you think this code could be better! Improvement suggestions always welcome.
+'use strict';
+
+// Feel free to make a PR with code comments on how you think this code could be better! Improvement suggestions always welcome.
+
+// Solution: if there is only 1 number that will appear an odd time, than if
+//           we see a number, then alternatively add or substract the number
+//           from a running sum, eventually only the sole number that appears
+//           odd times in the array will be left for this running sum.
+//
+//           Now consider this array:
+//               [1,2,1]
+//           1) at index = 0, sum = 0 + 1 * 1 = 1;   // 1 appears once so
+//              far, so factor = 1;
+//           2) at index = 1, sum = 1 + 1 * 2 = 3;   // 2 appears once so far,
+//             so factor = 1;
+//           3) for index = 2, we see number 1 again, but factor = -1,
+//              so sum = 3 + (-1 * 1) = 2,
+//           4) We've iterate the entire array and we're done, the number that
+//              appears odd times is 2 in this problem.
 function findOdd(A) {
-  const map = {}
-  for (num of A) {
+  const signs = {};
+  let sum = 0;
 
-    if (!map[num]) {
-      map[num] = 1
-
-    } else {
-      map[num]++
+  for (let num of A) {
+    // initialize the signs
+    if (!signs[num]) {
+      signs[num] = 1;
     }
-  }
-  
-  for (const num in map) {
-    if (map[num] % 2 === 1) {
-      return +num
-    }
+
+    // add the number with the appropriate sign; if this is the even time we
+    // see this number in the array, `signs[num] == -1`, and we will substract
+    // the number; otherwise, `signs[num] == 1`, we will add the number to the
+    // sum.
+    sum += signs[num] * num;
+
+    // flip the sign, next time we encounter the same number, we will use the
+    // flipped sign as the factor, and cancel out that number in the `sum`.
+    signs[num] *= -1;
   }
 
+  // whatever left in the sum, is the number that appears odd time
+  return sum;
 }
-
-function findMultiples

--- a/codewars/6kyu/Find-the-odd-int/answer.js
+++ b/codewars/6kyu/Find-the-odd-int/answer.js
@@ -2,12 +2,13 @@
 
 // Feel free to make a PR with code comments on how you think this code could be better! Improvement suggestions always welcome.
 
-// Solution: if there is only 1 number that will appear an odd time, than if
-//           we see a number, then alternatively add or substract the number
-//           from a running sum, eventually only the sole number that appears
-//           odd times in the array will be left for this running sum.
+// Solution: if there is only 1 number that appears odd times, then we can
+//           simplify the problem by alternatively adding or substracting
+//           the numbers in the array on a running sum. Eventually, only the
+//           sole number that appears odd times in the array will be left in
+//           this running sum.
 //
-//           Now consider this array:
+//           Consider this array example:
 //               [1,2,1]
 //           1) at index = 0, sum = 0 + 1 * 1 = 1;   // 1 appears once so
 //              far, so factor = 1;


### PR DESCRIPTION
This PR attempts to make a small adjustment to the algorithm that solves the "Find Odd Items" problem.

An observation can be made that since the array contains only a single number that will appear odd times, we can use a running sum to track array numbers and how many times they have shown up in the array, by making numbers cancel itself out along the scan using a running sum. In the end, what's left in the running sum will be that sole number appears odd times. 

Consider this array: [1,2,1], the initial running sum = 0.
1) at index 0, sum = sum + 1 * 1 = 1, factor is 1 since we see 1 for the first time.
2) at index 1, sum = sum + 1 * 2 = 3, factor is 1 since we see 2 for the first time.
3) at index 2, sum = sum + -1 * 1 = 2, factor is -1 since we see 1 for the even times, and it can cancel its previous appearing in the running sum.
4) we're done with the scan, the final result is sum = 2, since it's the only number that can't cancel itself out of the running sum.

The updated algorithm runs in O(n) time and uses O(n) extra space. It saves the loop over the `map` helper again after the initial array scan, which is a minor improvement. I suspect there may be an O(1) extra space solution, but it hasn't come to me yet. 

Please feel free to comment or let me know any amendment you'd suggest to this PR. 

Cheers!